### PR TITLE
Fixing usage CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ You can also use it to manually generate a `default.nix`:
 ```sh
 mix deps.get
 mix escript.build
-./mix2nix /path/to/mix.lock /path/to/default.nix
+./mix2nix /path/to/mix.lock > /path/to/default.nix
 ```


### PR DESCRIPTION
If called the way the `README` does, the CLI fails to match
the input pattern to a function.