### PR TITLE
evalMixConfig: *really* exit

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -249,7 +249,7 @@ let
     MIX_EXS = "${src}/mix.exs";
   } ''
     mix run --no-compile --no-deps-check --no-start \
-      --eval 'IO.puts inspect(Map.new(Mix.Project.config))' > $out
+      --eval 'IO.puts inspect(Map.new(Mix.Project.config)); System.halt(0)' > $out
   '';
 in
 


### PR DESCRIPTION
I was getting a situation where the mix-config.exs build was taking forever. This is my quick workaround.